### PR TITLE
Remove CCM integration for now

### DIFF
--- a/charts/proxmox/Chart.yaml
+++ b/charts/proxmox/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: proxmox-controllers
-description: A Helm chart for Proxmox controllers (CCM and CSI)
+description: Proxmox CSI Driver for Kubernetes
 type: application
 version: 0.1.0
 appVersion: "1.0.0"
@@ -8,12 +8,8 @@ icon: https://proxmox.com/pve/images/proxmox-logo.svg
 
 # Dependencies
 dependencies:
-  - name: proxmox-cloud-controller-manager
-    version: "0.2.13"
-    alias: ccm
-    enabled: false
-    repository: oci://ghcr.io/sergelogvinov/charts
   - name: proxmox-csi-plugin
     version: "0.3.5"
     alias: csi
+    enabled: true
     repository: oci://ghcr.io/sergelogvinov/charts

--- a/charts/proxmox/values.yaml
+++ b/charts/proxmox/values.yaml
@@ -1,33 +1,3 @@
-ccm:
-  enabledControllers: ['*']
-  config:
-    features:
-      provider: "proxmox"
-    clusters:
-      - url: "https://192.168.1.100:8006/api2/json"
-        insecure: true
-        token_id: kubernetes@pve!ccm
-        token_secret: "${PROXMOX_CCM_TOKEN_SECRET}"
-        region: "LAB"
-
-
-  # Use daemonset mode for RKE2 as recommended
-  useDaemonSet: true
-
-  # Set nodeSelector for control-plane nodes
-  nodeSelector:
-    node-role.kubernetes.io/control-plane: "true"
-
-  # Allow scheduling on control-plane nodes
-  tolerations:
-    - key: node-role.kubernetes.io/control-plane
-      effect: NoSchedule
-    - key: node-role.kubernetes.io/master
-      effect: NoSchedule
-    - key: node.cloudprovider.kubernetes.io/uninitialized
-      effect: NoSchedule
-      value: "true"
-
 csi:
   config:
     clusters:


### PR DESCRIPTION
This PR removes the Cloud Controller Manager (CCM) integration from our Proxmox setup for now, focusing solely on the CSI driver functionality.

## Changes
- Removed CCM dependency from `Chart.yaml`
- Removed CCM configuration from `values.yaml`
- Updated chart description to reflect CSI-only functionality
- Set CSI plugin to be enabled by default

## Reason for Change
We're focusing on getting the CSI driver working reliably first before adding CCM integration. This simplifies our initial deployment and troubleshooting process.

## Testing
- Verified that the Helm chart still installs correctly
- Confirmed CSI functionality remains unaffected
- Ensured no CCM-related resources are created

## Future Work
We'll reintroduce CCM integration in a future PR once we've stabilized the CSI driver implementation.